### PR TITLE
Update circle chrome and phantom

### DIFF
--- a/blueprints/circle-ci-chrome/files/circle.yml
+++ b/blueprints/circle-ci-chrome/files/circle.yml
@@ -4,6 +4,9 @@ machine:
 dependencies:
   pre:
     - npm install -g bower
+    - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+    - sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb stable main" >> /etc/apt/sources.list.d/google.list'
     - sudo apt-get update; sudo apt-get install -y --only-upgrade google-chrome-stable
   post:
+    - npm install
     - bower install

--- a/blueprints/circle-ci-phantom/files/circle.yml
+++ b/blueprints/circle-ci-phantom/files/circle.yml
@@ -7,4 +7,5 @@ dependencies:
   pre:
     - npm install -g bower
   post:
+    - npm install
     - bower install


### PR DESCRIPTION
Circle CI Requires you have public key and repo added before running those apt commands.
Also, both Circle CI Chrome and Phantomjs files were missing `npm install`